### PR TITLE
package.json - add dependencies, including tafax/angular-state-machine

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,11 @@
     "type": "git",
     "url": "git://github.com/tafax/angular-digest-auth.git"
   },
+  "dependencies": {
+    "angular": "*",
+    "angular-md5": "*",
+    "angular-state-machine": "git://github.com/tafax/angular-state-machine"
+  },
   "devDependencies": {
     "grunt-cli": ">= 0.1.7",
     "grunt-contrib-uglify": "*",


### PR DESCRIPTION
Dependency on angular-state-machine is via github. Allows installation using npm.  See issue #14 in tafax/angular-digest-auth.

Obviously it would make use of this module even more convenient if you publish this module on npm, as per https://docs.npmjs.com/getting-started/publishing-npm-packages 

If you do, the package.json dependencies need to be updated to start getting them from npm rather than github.

Note, I get the following warnings when installing via npm, which I believe are unrelated to my changes:

    $ npm install
    npm WARN engine get-stdin@5.0.0: wanted: {"node":">=0.12.0"} (current: {"node":"0.10.37","npm":"1.4.28"})
    npm WARN optional dep failed, continuing fsevents@0.2.1
    npm WARN engine hoek@2.16.3: wanted: {"node":">=0.10.40"} (current: {"node":"0.10.37","npm":"1.4.28"})
    npm WARN engine cryptiles@2.0.5: wanted: {"node":">=0.10.40"} (current: {"node":"0.10.37","npm":"1.4.28"})
    npm WARN engine boom@2.10.1: wanted: {"node":">=0.10.40"} (current: {"node":"0.10.37","npm":"1.4.28"})
    ... 
