### PR TITLE
Use credentials only once

### DIFF
--- a/src/config/config-state-machine.js
+++ b/src/config/config-state-machine.js
@@ -37,6 +37,7 @@ dgAuth.config(['stateMachineProvider', function(stateMachineProvider)
                 {
                     var credentials = params.credentials;
                     authService.setCredentials(credentials.username, credentials.password);
+                    delete params.credentials;
                 }
             }]
         },
@@ -108,6 +109,7 @@ dgAuth.config(['stateMachineProvider', function(stateMachineProvider)
                     authService.clearRequest();
                     authService.clearCredentials();
                     authStorage.clearCredentials();
+                    delete params.credentials;
 
                     var callbacksLogout = authService.getCallbacks('logout.successful');
                     for(var i in callbacksLogout)
@@ -144,6 +146,11 @@ dgAuth.config(['stateMachineProvider', function(stateMachineProvider)
             {
                 if(name == 'logoutRequest')
                 {
+                    authIdentity.clear();
+                    authService.clearRequest();
+                    authService.clearCredentials();
+                    authStorage.clearCredentials();
+                    delete params.credentials;
                     var callbacksLogout = authService.getCallbacks('logout.error');
                     for(var i in callbacksLogout)
                     {

--- a/src/config/config-state-machine.js
+++ b/src/config/config-state-machine.js
@@ -66,7 +66,8 @@ dgAuth.config(['stateMachineProvider', function(stateMachineProvider)
                         return !authRequests.getValid();
                     }]
                 }],
-                201: 'loggedIn'
+                201: 'loggedIn',
+                failure: 'loginError'
             },
             //Does the request to the server and save the promise
             action: ['authRequests', function(authRequests)

--- a/src/services/auth-requests.js
+++ b/src/services/auth-requests.js
@@ -123,6 +123,8 @@ dgAuth.provider('authRequests', ['dgAuthServiceProvider', function AuthRequestsP
                 },
                 function(response)
                 {
+                    stateMachine.send('401', {response: response});
+                    
                     return response;
                 });
             return _promise;


### PR DESCRIPTION
I propose this fix for the issue #24.

This fix allow too : 
- to trigger the callback function on logout
- to add a callback function on `failure` state